### PR TITLE
chore: update peer deps

### DIFF
--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -23,6 +23,6 @@
   "peerDependencies": {
     "@dikur/http": "^0.2.3",
     "ajv": "^8.12.0",
-    "hono": "^3.1.8"
+    "hono": "^4.0.0"
   }
 }


### PR DESCRIPTION
Currently, only Hono version 3 is supported. This PR updates the peer dependencies to allow for Hono version 4.

Tests are failing. Will investigate

```bash
Suites:   4 failed, 4 of 4 completed
Asserts:  4 failed, of 4
```
